### PR TITLE
Remove JWT verification and allow CORS

### DIFF
--- a/back-end/domains/bookings/routes.js
+++ b/back-end/domains/bookings/routes.js
@@ -1,29 +1,20 @@
 import { Router } from "express";
 import Booking from "./model.js";
 import { connectDb } from "../../config/db.js";
-import { JWTVerify } from "../../utils/jwt.js";
 
 const router = Router();
 
+// JWT verification removed: return all bookings
 router.get("/owner", async (req, res) => {
   connectDb();
 
   try {
-    const { _id: id } = await JWTVerify(req);
+    const bookingDocs = await Booking.find().populate("place");
 
-    try {
-      const bookingDocs = await Booking.find({ user: id }).populate("place");
-
-      res.json(bookingDocs);
-    } catch (error) {
-      console.error(error);
-      res
-        .status(500)
-        .json("Deu erro ao buscar todas as Reservas daquele usuário");
-    }
+    res.json(bookingDocs);
   } catch (error) {
     console.error(error);
-    res.status(500).json("Deu erro ao validar o token do usuário");
+    res.status(500).json("Deu erro ao buscar todas as Reservas");
   }
 });
 
@@ -56,41 +47,11 @@ router.delete("/:id", async (req, res) => {
   const { id } = req.params;
 
   try {
-    // Verify JWT
-    const userInfo = await JWTVerify(req);
+    await Booking.findByIdAndDelete(id);
 
-    // Validate ID format if needed (optional)
-    if (!mongoose.Types.ObjectId.isValid(id)) {
-      return res.status(400).json("ID inválido");
-    }
-
-    // Find and verify the booking
-    const bookingDoc = await Booking.findById(id);
-
-    if (!bookingDoc) {
-      return res.status(404).json("Reserva não encontrada");
-    }
-
-    // Verify ownership
-    if (bookingDoc.user.toString() !== userInfo._id) {
-      return res.status(403).json("A reserva não pertence ao usuário");
-    }
-
-    // Delete the document
-    await bookingDoc.deleteOne();
-
-    // 204 is more appropriate for deletions
     return res.status(204).end();
-
   } catch (error) {
     console.error("Delete error:", error);
-
-    // Handle specific errors
-    if (error.name === 'CastError') {
-      return res.status(400).json("ID inválido");
-    }
-
-    // Generic error response
     return res.status(500).json("Erro ao cancelar a reserva");
   }
 });

--- a/back-end/domains/places/routes.js
+++ b/back-end/domains/places/routes.js
@@ -1,6 +1,5 @@
 import { Router } from "express";
 import Place from "./model.js";
-import { JWTVerify } from "../../utils/jwt.js";
 import { connectDb } from "../../config/db.js";
 import { sendToS3, downloadImage, uploadImage } from "./controller.js";
 
@@ -19,23 +18,17 @@ router.get("/", async (req, res) => {
   }
 });
 
+// JWT verification removed: return all places
 router.get("/owner", async (req, res) => {
   connectDb();
 
   try {
-    const userInfo = await JWTVerify(req);
+    const placeDocs = await Place.find();
 
-    try {
-      const placeDocs = await Place.find({ owner: userInfo._id });
-
-      res.json(placeDocs);
-    } catch (error) {
-      console.error(error);
-      res.status(500).json("Deu erro encontrar as Acomodações");
-    }
+    res.json(placeDocs);
   } catch (error) {
     console.error(error);
-    res.status(500).json("Deu erro verificar o usuário");
+    res.status(500).json("Deu erro encontrar as Acomodações");
   }
 });
 
@@ -100,6 +93,7 @@ router.post("/", async (req, res) => {
   connectDb();
 
   const {
+    owner,
     title,
     city,
     photos,
@@ -113,8 +107,6 @@ router.post("/", async (req, res) => {
   } = req.body;
 
   try {
-    const { _id: owner } = await JWTVerify(req);
-
     const newPlaceDoc = await Place.create({
       owner,
       title,

--- a/back-end/domains/users/routes.js
+++ b/back-end/domains/users/routes.js
@@ -3,12 +3,10 @@ import { Router } from "express";
 import { connectDb } from "../../config/db.js";
 import User from "./model.js";
 import bcrypt from "bcryptjs";
-import jwt from "jsonwebtoken";
-import { JWTVerify, JWTSign } from "../../utils/jwt.js";
+import { JWTSign } from "../../utils/jwt.js";
 
 const router = Router();
 const bcryptSalt = bcrypt.genSaltSync();
-const { JWT_SECRET_KEY } = process.env;
 
 router.get("/", async (req, res) => {
   connectDb();
@@ -22,10 +20,9 @@ router.get("/", async (req, res) => {
   }
 });
 
+// JWT verification removed: always return null
 router.get("/profile", async (req, res) => {
-  const userInfo = await JWTVerify(req);
-
-  res.json(userInfo);
+  res.json(null);
 });
 
 router.post("/", async (req, res) => {

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -12,9 +12,10 @@ export const __dirname = dirname(__filename);
 
 app.use(express.json());
 app.use(cookieParser());
+// allow all CORS requests
 app.use(
   cors({
-    origin: "http://localhost:5173",
+    origin: true,
     credentials: true,
   })
 );


### PR DESCRIPTION
## Summary
- disable JWT verification in all API routes
- return empty profile information instead of checking JWT
- allow CORS from any origin

## Testing
- `npm run build` *(fails: npm could not download packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6870fca3678c83258818448880010497